### PR TITLE
Fix missing template registration

### DIFF
--- a/Assembly-CSharp/Tanks/Lobby/ClientProfile/Impl/TanksClientProfileActivator.cs
+++ b/Assembly-CSharp/Tanks/Lobby/ClientProfile/Impl/TanksClientProfileActivator.cs
@@ -3,6 +3,7 @@ using Platform.Kernel.OSGi.ClientCore.API;
 using Platform.Library.ClientUnityIntegration;
 using Platform.Library.ClientUnityIntegration.API;
 using Tanks.Lobby.ClientProfile.API;
+using Tanks.Lobby.ClientSettings.API;
 
 namespace Tanks.Lobby.ClientProfile.Impl
 {
@@ -23,8 +24,9 @@ namespace Tanks.Lobby.ClientProfile.Impl
 			ECSBehaviour.EngineService.RegisterSystem(new LaserSightSettingsSystem());
 			ECSBehaviour.EngineService.RegisterSystem(new UserXCrystalsIndicatorSystem());
 			ECSBehaviour.EngineService.RegisterSystem(new MouseSettingsSystem());
-			ECSBehaviour.EngineService.RegisterSystem(new CBQAchievementSystem());
-			TemplateRegistry.RegisterPart<TanksSettingsTemplatePart>();
+                        ECSBehaviour.EngineService.RegisterSystem(new CBQAchievementSystem());
+                        TemplateRegistry.Register<SettingsTemplate>();
+                        TemplateRegistry.RegisterPart<TanksSettingsTemplatePart>();
 			TemplateRegistry.RegisterPart<MouseSettingsTemplatePart>();
 			TemplateRegistry.RegisterPart<GameCameraShakerSettingsTemplatePart>();
 			TemplateRegistry.RegisterPart<TargetFocusSettingsTemplatePart>();


### PR DESCRIPTION
## Summary
- ensure SettingsTemplate is registered before part templates in `TanksClientProfileActivator`
- add required namespace import

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68791fbba1e883319e148a6edcde5450