### PR TITLE
Update asset tools and fix error links

### DIFF
--- a/config/clientlocal/ui/screen/error/client_expired/public_en.yml
+++ b/config/clientlocal/ui/screen/error/client_expired/public_en.yml
@@ -3,4 +3,4 @@ errorText: |
   If the update wasn't downloaded and installed automatically, please restart Steam.
 reConnectTime: 999999 # hack: hides restart button
 reportButtonLabel: DETAILS
-reportUrl: https://help.tankix.com/en/tanki-x/TODO
+reportUrl: https://help.tankix.com/en/tanki-x/articles/issues/client-expired

--- a/config/clientlocal/ui/screen/error/client_expired/public_ru.yml
+++ b/config/clientlocal/ui/screen/error/client_expired/public_ru.yml
@@ -3,4 +3,4 @@ errorText: |
   Если обновление не загрузилось автоматически, перезапустите Steam.
 reConnectTime: 999999 # hack: hides restart button
 reportButtonLabel: ПОДРОБНЕЕ
-reportUrl: https://help.tankix.com/ru/tanki-x/TODO
+reportUrl: https://help.tankix.com/ru/tanki-x/articles/problems/client-expired

--- a/config/clientlocal/ui/screen/error/client_expired/public_tr.yml
+++ b/config/clientlocal/ui/screen/error/client_expired/public_tr.yml
@@ -4,4 +4,4 @@ errorText: |
   Eğer güncelleme otomatik olarak indirilip yüklenmediyse, lütfen Steam'i yeniden başlatın.
 reConnectTime: 999999
 reportButtonLabel: AYRINTILAR
-reportUrl: https://help.tankix.com/en/tanki-x/TODO
+reportUrl: https://help.tankix.com/en/tanki-x/articles/issues/client-expired

--- a/tools/GenerateAssetBundleDB.cs
+++ b/tools/GenerateAssetBundleDB.cs
@@ -4,7 +4,6 @@ using System.IO;
 #if UNITY_EDITOR
 using UnityEditor;
 #endif
-using UnityEditor;
 using UnityEngine;
 
 public static class GenerateAssetBundleDB
@@ -62,8 +61,6 @@ public static class GenerateAssetBundleDB
         UnityEngine.Debug.LogError("GenerateAssetBundleDB can only run inside the Unity Editor.");
     }
 #endif
-        Debug.Log("db.json generated at " + Path.Combine(outputPath, "db.json"));
-    }
 
     [Serializable]
     class Db

--- a/tools/RestoreGuidsFromDb.cs
+++ b/tools/RestoreGuidsFromDb.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
+using UnityEngine;
+
+public static class RestoreGuidsFromDb
+{
+#if UNITY_EDITOR
+    [MenuItem("Tools/Restore GUIDs From DB")]
+    public static void Restore()
+    {
+        string dbPath = Path.Combine(Application.dataPath, "..", "db.json");
+        if (!File.Exists(dbPath))
+        {
+            Debug.LogError($"db.json not found at {dbPath}");
+            return;
+        }
+
+        Db db = JsonUtility.FromJson<Db>(File.ReadAllText(dbPath));
+        foreach (var bundle in db.bundles)
+        {
+            foreach (var asset in bundle.assets)
+            {
+                string metaPath = asset.objectName + ".meta";
+                if (!File.Exists(metaPath))
+                {
+                    Debug.LogWarning($"Meta file not found for {asset.objectName}");
+                    continue;
+                }
+
+                var lines = File.ReadAllLines(metaPath);
+                for (int i = 0; i < lines.Length; i++)
+                {
+                    if (lines[i].StartsWith("guid:"))
+                    {
+                        lines[i] = "guid: " + asset.guid;
+                        break;
+                    }
+                }
+                File.WriteAllLines(metaPath, lines);
+            }
+        }
+        AssetDatabase.Refresh();
+        Debug.Log("GUIDs restored from db.json");
+    }
+#else
+    public static void Restore()
+    {
+        Debug.LogError("RestoreGuidsFromDb can only run inside the Unity Editor.");
+    }
+#endif
+
+    [Serializable]
+    class Db
+    {
+        public List<BundleInfo> bundles = new List<BundleInfo>();
+    }
+
+    [Serializable]
+    class BundleInfo
+    {
+        public List<AssetInfo> assets = new List<AssetInfo>();
+    }
+
+    [Serializable]
+    class AssetInfo
+    {
+        public string guid;
+        public string objectName;
+    }
+}


### PR DESCRIPTION
## Summary
- fix editor guards in `GenerateAssetBundleDB`
- add a utility to restore asset GUIDs from `db.json`
- patch error screen configuration links

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687a56b782b08331897359033ce0eb74